### PR TITLE
Automatically install kaleido binaries also on Linux aarch64

### DIFF
--- a/plotly_kaleido/build.rs
+++ b/plotly_kaleido/build.rs
@@ -10,9 +10,13 @@ use std::process::Command;
 
 use directories::ProjectDirs;
 
-#[cfg(target_os = "linux")]
+#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
 const KALEIDO_URL: &str =
     "https://github.com/plotly/Kaleido/releases/download/v0.2.1/kaleido_linux_x64.zip";
+
+#[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+const KALEIDO_URL: &str =
+    "https://github.com/plotly/Kaleido/releases/download/v0.2.1/kaleido_linux_arm64.zip";
 
 #[cfg(target_os = "windows")]
 const KALEIDO_URL: &str =


### PR DESCRIPTION
With this change it is possible to use kaleido on Linux aarch64: https://repos.openhpc.community/stats/unique_visitors_per_month.svg