### PR TITLE
fix hyperlinks to point to new repository url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,36 +5,36 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [0.8.5] - 2024-xx-xx
 ### Added
-- [[#181](https://github.com/igiagkiozis/plotly/pull/181)] Fix compilation error when mixing the crate with `askama/with-axum` by adding `with-axum` feature.
-- [[#180](https://github.com/igiagkiozis/plotly/pull/180)] Add setter for `Mapbox::domain`.
+- [[#181](https://github.com/plotly/plotly,rs/pull/181)] Fix compilation error when mixing the crate with `askama/with-axum` by adding `with-axum` feature.
+- [[#180](https://github.com/plotly/plotly.rs/pull/180)] Add setter for `Mapbox::domain`.
 - [[#163](https://github.com/plotly/plotly.rs/pull/163)] Added `DensityMapbox`.
-- [[#153](https://github.com/igiagkiozis/plotly/pull/153)] Added `LayoutScene`.
+- [[#153](https://github.com/plotly/plotly.rs/pull/153)] Added `LayoutScene`.
 
 ## [0.8.4] - 2023-07-09
 ### Added
-- [[#143](https://github.com/igiagkiozis/plotly/pull/143)] Widen version range of `askama`.
+- [[#143](https://github.com/plotly/plotly.rs/pull/143)] Widen version range of `askama`.
 
 ### Fixed
-- [[#129](https://github.com/igiagkiozis/plotly/pull/129)] Fix issue for plots not showing in browser in Windows. Thanks to [@juanespj](https://github.com/juanespj) and [@M-NK-Y](https://github.com/M-NK-Y) for the PRs.
-- [[#147](https://github.com/igiagkiozis/plotly/pull/147)] Update documentation for `jupyter notebook` example.
+- [[#129](https://github.com/plotly/plotly.rs/pull/129)] Fix issue for plots not showing in browser in Windows. Thanks to [@juanespj](https://github.com/juanespj) and [@M-NK-Y](https://github.com/M-NK-Y) for the PRs.
+- [[#147](https://github.com/plotly/plotly.rs/pull/147)] Update documentation for `jupyter notebook` example.
 
 ## [0.8.3] - 2022-11-04
 ### Fixed
-- [[#122](https://github.com/igiagkiozis/plotly/pull/122)] Compilation error for the `wasm` feature.
-- [[#123](https://github.com/igiagkiozis/plotly/pull/123)] Compilation error for the `plotly_kaleido` feature.
+- [[#122](https://github.com/plotly/plotly.rs/pull/122)] Compilation error for the `wasm` feature.
+- [[#123](https://github.com/plotly/plotly.rs/pull/123)] Compilation error for the `plotly_kaleido` feature.
 
 ## [0.8.2] - 2022-11-03
 ### Added
-- [[#110](https://github.com/igiagkiozis/plotly/pull/110)] `LegendGroupTitle` to existing traces.
-- [[#88](https://github.com/igiagkiozis/plotly/pull/88)] `Mesh3D`, `Image`, `ScatterMapbox` traces.
+- [[#110](https://github.com/plotly/plotly.rs/pull/110)] `LegendGroupTitle` to existing traces.
+- [[#88](https://github.com/plotly/plotly.rs/pull/88)] `Mesh3D`, `Image`, `ScatterMapbox` traces.
 
 ### Changed
-- [[#113](https://github.com/igiagkiozis/plotly/pull/113)] Refactored the structure of the examples to make them more accessible, whilst adding more examples e.g. for `wasm`.
-- [[#115](https://github.com/igiagkiozis/plotly/pull/115)] Simplify the function signature of Plot.to_inline_html() so that it just takes `Option<&str>` as an argument.
+- [[#113](https://github.com/plotly/plotly.rs/pull/113)] Refactored the structure of the examples to make them more accessible, whilst adding more examples e.g. for `wasm`.
+- [[#115](https://github.com/plotly/plotly.rs/pull/115)] Simplify the function signature of Plot.to_inline_html() so that it just takes `Option<&str>` as an argument.
 
 ## [0.8.1] - 2022-09-25
 ### Added
-- Button support (i.e. [updatemenus](https://plotly.com/javascript/reference/layout/updatemenus/)) contibuted by [@sreenathkrishnan](https://github.com/sreenathkrishnan). Details and examples in this well written PR [#99](https://github.com/igiagkiozis/plotly/pull/99).
+- Button support (i.e. [updatemenus](https://plotly.com/javascript/reference/layout/updatemenus/)) contibuted by [@sreenathkrishnan](https://github.com/sreenathkrishnan). Details and examples in this well written PR [#99](https://github.com/plotly/plotly.rs/pull/99).
 - Internally, there is now a `plotly-derive` crate which defines a `FieldSetter` procedural macro. This massively cuts down the amount of code duplication by generating the setter methods based on the struct fields. Again thanks to @sreenathkrishnan for this effort.
 
 ## [0.8.0] - 2022-08-26
@@ -49,7 +49,7 @@ Version 0.8.0 represents a significant release which refactors a lot of the code
 - Support for `Sankey` diagrams
 - Support for `Plot3D` - 3D plots for scatter, line and surface data
 ### Changed
-- Improve implementation of `private::NumOrString` to support more primitive types ([Issue #47](https://github.com/igiagkiozis/plotly/issues/47))
+- Improve implementation of `private::NumOrString` to support more primitive types ([Issue #47](https://github.com/plotly/plotly.rs/issues/47))
 - Remove `private::TruthyEnum` in favour of a more robust way of serializing to `String` or `bool`
 - Refactor `Color` module
 - Refactored HTML templates with cleaner Javascript code
@@ -59,7 +59,7 @@ Version 0.8.0 represents a significant release which refactors a lot of the code
 - `Plot::to_html()` now has similar behaviour to `Plot::to_inline_html()` and just returns a `String`
 ### Fixed
 - Typos in `CONTRIBUTING.md`
-- Serialization of `plotly_kaleido::PlotData` ([Issue #50](https://github.com/igiagkiozis/plotly/issues/50))
+- Serialization of `plotly_kaleido::PlotData` ([Issue #50](https://github.com/plotly/plotly.rs/issues/50))
 ### Updated
 - `ndarray` to `0.15.4`.
 - `serde` to `1.0.132`.
@@ -87,11 +87,11 @@ Version 0.8.0 represents a significant release which refactors a lot of the code
 
 ## [0.6.0] - 2020-07-25
 ### Added
-- Shapes support ([documentation](https://igiagkiozis.github.io/plotly/content/fundamentals/shapes.html)).
+- Shapes support ([documentation](https://plotly.github.io/plotly.rs/content/fundamentals/shapes.html)).
 - Annotations support.
 - Docstrings to `Scatter`.
-- `ndarray` support ([documentation](https://igiagkiozis.github.io/plotly/content/fundamentals/ndarray_support.html)).
-- Jupyter lab and notebook support ([documentation](https://igiagkiozis.github.io/plotly/content/fundamentals/jupyter_support.html)).
+- `ndarray` support ([documentation](https://plotly.github.io/plotly.rs/content/fundamentals/ndarray_support.html)).
+- Jupyter lab and notebook support ([documentation](https://plotly.github.io/plotly.rs/content/fundamentals/jupyter_support.html)).
 ### Changed
 - Removed `num` dependence.
 - Removed `plotly_orca` and the `orca` feature. Use the `kaleido` feature for static image generation.
@@ -109,7 +109,7 @@ Version 0.8.0 represents a significant release which refactors a lot of the code
 
 ## [0.5.0] - 2020-07-12
 ### Added
-- [Plotly.rs Book](https://igiagkiozis.github.io/plotly/).
+- [Plotly.rs Book](https://plotly.github.io/plotly.rs/).
 - Using plotly.js from the official CDN is now the default. To use the local version use the `Plot::use_local_plotly` method.
 - Plot rasterization to `png`, `jpg`, `eps`, `pdf`, `webp` and `svg` using [plotly/Kaleido](https://github.com/plotly/Kaleido), enabled using the `kaleido` feature.
 - Multi-axis support and examples.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,11 +12,11 @@ When making a feature request, please make it clear what problem you intend to s
 
 ## Pull Requests
 
-Before spending time and effort in making changes to the library, it's a good idea to discuss it first on the issue tracker to see whether your change is likely to be accepted. 
+Before spending time and effort in making changes to the library, it's a good idea to discuss it first on the issue tracker to see whether your change is likely to be accepted.
 
-Fork [plotly](https://igiagkiozis.github.io/plotly/) to your own account and create a new branch for your feature. Remember to update the [changelog](CHANGELOG.md) - use previous entries as a template. 
+Fork [plotly](https://github.com/plotly/plotly.rs.git) to your own account and create a new branch for your feature. Remember to update the [changelog](CHANGELOG.md) - use previous entries as a template.
 
-When your contribution is ready for review, make a pull request with your changes directly to the `master` branch. One of the maintainers will have a look at what you've done, suggest any necessary changes and, when everyone is happy, merge the pull request.
+When your contribution is ready for review, make a pull request with your changes directly to the `main` branch. One of the maintainers will have a look at what you've done, suggest any necessary changes and, when everyone is happy, merge the pull request.
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
   <h1>Plotly.rs</h1>
   <p><strong>Plotly for Rust</strong></p>
   <p>
-    <a href="https://github.com/igiagkiozis/plotly/actions?query=branch%3Amaster" style="text-decoration: none!important;">
-        <img src="https://img.shields.io/github/actions/workflow/status/igiagkiozis/plotly/ci.yml?branch=master" alt="Build status">
+    <a href="https://github.com/plotly/plotly.rs/actions?query=branch%3Amain" style="text-decoration: none!important;">
+        <img src="https://img.shields.io/github/actions/workflow/status/plotly/plotly.rs/ci.yml?branch=main" alt="Build status">
     </a>
     <a href="https://crates.io/crates/plotly" style="text-decoration: none!important;">
         <img src="https://img.shields.io/crates/v/plotly.svg" alt="Crates.io">
@@ -14,18 +14,18 @@
 	<a href="https://docs.rs/plotly" style="text-decoration: none!important;">
         <img src="https://img.shields.io/badge/docs.rs-plotly-green" alt="Documentation">
     </a>
-	<a href="https://app.codecov.io/github/igiagkiozis/plotly" style="text-decoration: none!important;">
+	<a href="https://app.codecov.io/github/plotly/plotly.rs" style="text-decoration: none!important;">
         <img src="https://img.shields.io/codecov/c/github/igiagkiozis/plotly" alt="Code coverage">
     </a>
   </p>
   <h4>
-    <a href="https://igiagkiozis.github.io/plotly/content/getting_started.html">Getting Started</a>
+    <a href="https://plotly.github.io/plotly.rs/content/getting_started.html">Getting Started</a>
     <span> | </span>
-    <a href="https://igiagkiozis.github.io/plotly/content/recipes.html">Recipes</a>
+    <a href="https://plotly.github.io/plotly.rs/content/recipes.html">Recipes</a>
     <span> | </span>
     <a href="https://docs.rs/crate/plotly/">API Docs</a>
     <span> | </span>
-    <a href="https://github.com/igiagkiozis/plotly/blob/master/CHANGELOG.md">Changelog</a>
+    <a href="https://github.com/plotly/plotly.rs/tree/main/CHANGELOG.md">Changelog</a>
   </h4>
 </div>
 
@@ -44,10 +44,10 @@
 
 A plotting library for Rust powered by [Plotly.js](https://plot.ly/javascript/).
 
-Documentation and numerous interactive examples are available in the [Plotly.rs Book](https://igiagkiozis.github.io/plotly/content/getting_started.html), the [examples/](https://github.com/igiagkiozis/plotly/tree/master/examples) directory and [docs.rs](https://docs.rs/crate/plotly).
+Documentation and numerous interactive examples are available in the [Plotly.rs Book](https://plotly.github.io/plotly.rs/content/getting_started.html), the [examples/](https://github.com/plotly/plotly.rs/tree/main/examples) directory and [docs.rs](https://docs.rs/crate/plotly).
 
 
-For changes since the last version, please consult the [changelog](https://github.com/igiagkiozis/plotly/blob/master/CHANGELOG.md).
+For changes since the last version, please consult the [changelog](https://github.com/plotly/plotly.rs/tree/main/CHANGELOG.md).
 
 # Basic Usage
 
@@ -163,13 +163,13 @@ pub fn plot_component() -> Html {
         }
     });
 
-    
+
         use_effect_with_deps(move |_| {
             p.run();
             || ()
         }, (),
     );
-    
+
 
     html! {
         <div id="plot-div"></div>
@@ -177,7 +177,7 @@ pub fn plot_component() -> Html {
 }
 ```
 
-More detailed standalone examples can be found in the [examples/](https://github.com/igiagkiozis/plotly/tree/master/examples) directory.
+More detailed standalone examples can be found in the [examples/](https://github.com/plotly/plotly.rs/tree/main/examples) directory.
 
 # Crate Feature Flags
 
@@ -201,12 +201,12 @@ Enables compilation for the `wasm32-unknown-unknown` target and provides access 
 
 # Contributing
 
-* If you've spotted a bug or would like to see a new feature, please submit an issue on the [issue tracker](https://github.com/igiagkiozis/plotly/issues).
+* If you've spotted a bug or would like to see a new feature, please submit an issue on the [issue tracker](https://github.com/plotly/plotly.rs/issues).
 
-* Pull requests are welcome, see the [contributing guide](https://github.com/igiagkiozis/plotly/blob/master/CONTRIBUTING.md) for more information.
+* Pull requests are welcome, see the [contributing guide](https://github.com/plotly/plotly.rs/tree/main/CONTRIBUTING.md) for more information.
 
 # License
 
 `Plotly.rs` is distributed under the terms of the MIT license.
 
-See [LICENSE-MIT](https://github.com/igiagkiozis/plotly/blob/master/LICENSE-MIT), and [COPYRIGHT](https://github.com/igiagkiozis/plotly/blob/master/COPYRIGHT) for details.
+See [LICENSE-MIT](https://github.com/plotly/plotly.rs/tree/main/LICENSE-MIT), and [COPYRIGHT](https://github.com/plotly/plotly.rs/tree/main/COPYRIGHT) for details.

--- a/docs/book/src/fundamentals.md
+++ b/docs/book/src/fundamentals.md
@@ -1,9 +1,9 @@
 <div align="center">
-    <a href="https://github.com/igiagkiozis/plotly/tree/master">
-        <img src="https://img.shields.io/badge/Plotly.rs-master-brightgreen" alt="build status">
+    <a href="https://github.com/plotly/plotly.rs/tree/main">
+        <img src="https://img.shields.io/badge/Plotly.rs-main-brightgreen" alt="build status">
     </a>
-    <a href="https://github.com/igiagkiozis/plotly/actions">
-        <img src="https://github.com/igiagkiozis/plotly/workflows/build/badge.svg" alt="build status">
+    <a href="https://github.com/plotly/plotly.rs/actions?query=branch%3Amain" style="text-decoration: none!important;">
+        <img src="https://img.shields.io/github/actions/workflow/status/plotly/plotly.rs/ci.yml?branch=main" alt="Build status">
     </a>
     <a href="https://crates.io/crates/plotly">
         <img src="https://img.shields.io/crates/v/plotly.svg" alt="Crates.io">
@@ -18,4 +18,4 @@
 
 # Fundamentals
 
-Functionality that applies to the library as a whole is described in the next sections. 
+Functionality that applies to the library as a whole is described in the next sections.

--- a/docs/book/src/fundamentals/jupyter_support.md
+++ b/docs/book/src/fundamentals/jupyter_support.md
@@ -1,12 +1,12 @@
 # Jupyter Support
 
-As of version `0.7.0`, [Plotly.rs](https://github.com/igiagkiozis/plotly) has native support for the [EvCxR Jupyter Kernel](https://github.com/google/evcxr/tree/master/evcxr_jupyter). 
+As of version `0.7.0`, [Plotly.rs](https://github.com/plotly/plotly.rs) has native support for the [EvCxR Jupyter Kernel](https://github.com/google/evcxr/tree/master/evcxr_jupyter).
 
 Once you've installed the required packages you'll be able to run all the examples shown here as well as all [the recipes](../recipes.md) in Jupyter Lab!
 
 
 ## Installation
-It is assumed that an installation of the [Anaconda](https://www.anaconda.com/products/individual) Python distribution is already present in the system. If that is not the case you can follow these [instructions](https://www.anaconda.com/products/individual) to get up and running with `Anaconda`. 
+It is assumed that an installation of the [Anaconda](https://www.anaconda.com/products/individual) Python distribution is already present in the system. If that is not the case you can follow these [instructions](https://www.anaconda.com/products/individual) to get up and running with `Anaconda`.
 
 ```shell script
 conda install -c plotly plotly=4.9.0
@@ -20,17 +20,17 @@ conda install notebook
 
 Although there are alternative methods to enable support for the [EvCxR Jupyter Kernel](https://github.com/google/evcxr/tree/master/evcxr_jupyter), we have elected to keep the requirements consistent with what those of other languages, e.g. Julia, Python and R. This way users know what to expect; and also the folks at [Plotly](https://plotly.com/python/getting-started/#jupyter-notebook-support) have done already most of the heavy lifting to create an extension for Jupyter Lab that works very well.
 
-Run the following to install the Plotly Jupyter Lab extension: 
+Run the following to install the Plotly Jupyter Lab extension:
 ```shell script
 jupyter labextension install jupyterlab-plotly@4.9.0
 ```
 
-Once this step is complete to make sure the installation so far was successful, run the following command: 
+Once this step is complete to make sure the installation so far was successful, run the following command:
 ```shell script
 jupyter lab
 ```
 
-Open a `Python 3` kernel copy/paste the following code in a cell and run it: 
+Open a `Python 3` kernel copy/paste the following code in a cell and run it:
 ```python
 import plotly.graph_objects as go
 fig = go.Figure(data=go.Bar(x=['a', 'b', 'c'], y=[11, 22, 33]))
@@ -62,7 +62,7 @@ If you're not familiar with the EvCxR kernel it would be good that you at least 
 
 ## Usage
 
-Launch Jupyter Lab: 
+Launch Jupyter Lab:
 ```shell script
 jupyter lab
 ```
@@ -104,6 +104,6 @@ plot.set_layout(layout);
 plot.lab_display();
 format!("EVCXR_BEGIN_CONTENT application/vnd.plotly.v1+json\n{}\nEVCXR_END_CONTENT", plot.to_json())
 ```
-For Jupyter Lab there are two ways to display a plot in the `EvCxR` kernel, either have the plot object be in the last line without a semicolon or directly invoke the `Plot::lab_display` method on it; both have the same result. You can also find an example notebook [here](https://github.com/igiagkiozis/plotly/blob/master/examples/jupyter/jupyter_lab.ipynb) that will periodically be updated with examples.
+For Jupyter Lab there are two ways to display a plot in the `EvCxR` kernel, either have the plot object be in the last line without a semicolon or directly invoke the `Plot::lab_display` method on it; both have the same result. You can also find an example notebook [here](https://github.com/plotly/plotly.rs/tree/main/examples/jupyter/jupyter_lab.ipynb) that will periodically be updated with examples.
 
-The process for Jupyter Notebook is very much the same with one exception; the `Plot::notebook_display` method must be used to display the plot. You can find an example notebook [here](https://github.com/igiagkiozis/plotly/blob/master/examples/jupyter/jupyter_notebook.ipynb) 
+The process for Jupyter Notebook is very much the same with one exception; the `Plot::notebook_display` method must be used to display the plot. You can find an example notebook [here](https://github.com/plotly/plotly.rs/tree/main/examples/jupyter/jupyter_notebook.ipynb)

--- a/docs/book/src/fundamentals/ndarray_support.md
+++ b/docs/book/src/fundamentals/ndarray_support.md
@@ -1,16 +1,16 @@
-# `ndarray` Support 
+# `ndarray` Support
 
-To enable [ndarray](https://github.com/rust-ndarray/ndarray) support in [Plotly.rs](https://github.com/igiagkiozis/plotly) add the following feature to your `Cargo.toml` file:
+To enable [ndarray](https://github.com/rust-ndarray/ndarray) support in [Plotly.rs](https://github.com/plotly/plotly.rs) add the following feature to your `Cargo.toml` file:
 ```toml
 [dependencies]
 plotly = { version = ">=0.7.0", features = ["plotly_ndarray"] }
 ```
 
-This extends the [Plotly.rs](https://github.com/igiagkiozis/plotly) API in two ways: 
+This extends the [Plotly.rs](https://github.com/plotly/plotly.rs) API in two ways:
 * `Scatter` traces can now be created using the `Scatter::from_ndarray` constructor,
 * and also multiple traces can be created with the `Scatter::to_traces` method.
 
-The full source code for the examples below can be found [here](https://github.com/igiagkiozis/plotly/blob/master/plotly/examples/ndarray_support.rs).
+The full source code for the examples below can be found [here](https://github.com/plotly/plotly.rs/tree/main/examples/ndarray_support).
 
 ## `ndarray` Traces
 
@@ -55,7 +55,7 @@ var layout = {};
 </script>
 
 ### Multiple Traces
-To display a `2D` array (`Array<_, Ix2>`) you can use the `Scatter::to_traces` method. The first argument of the method represents the common axis for the traces (`x` axis) whilst the second argument contains a collection of traces. At this point it should be noted that there is some ambiguity when passing a `2D` array; namely are the traces arranged along the columns or the rows of the matrix? This ambiguity is resolved by the third argument of the `Scatter::to_traces` method. If that argument is set to `ArrayTraces::OverColumns` then the library assumes that every column represents an individual trace, alternatively if this is set to `ArrayTraces::OverRows` the assumption is that every row represents a trace.   
+To display a `2D` array (`Array<_, Ix2>`) you can use the `Scatter::to_traces` method. The first argument of the method represents the common axis for the traces (`x` axis) whilst the second argument contains a collection of traces. At this point it should be noted that there is some ambiguity when passing a `2D` array; namely are the traces arranged along the columns or the rows of the matrix? This ambiguity is resolved by the third argument of the `Scatter::to_traces` method. If that argument is set to `ArrayTraces::OverColumns` then the library assumes that every column represents an individual trace, alternatively if this is set to `ArrayTraces::OverRows` the assumption is that every row represents a trace.
 
 To illustrate this distinction consider the following examples:
 ```rust

--- a/docs/book/src/getting_started.md
+++ b/docs/book/src/getting_started.md
@@ -1,9 +1,9 @@
 <div align="center">
-    <a href="https://github.com/igiagkiozis/plotly/tree/master">
-        <img src="https://img.shields.io/badge/Plotly.rs-master-brightgreen" alt="build status">
+    <a href="https://github.com/plotly/plotly.rs/tree/main">
+        <img src="https://img.shields.io/badge/Plotly.rs-main-brightgreen" alt="build status">
     </a>
-    <a href="https://github.com/igiagkiozis/plotly/actions">
-        <img src="https://github.com/igiagkiozis/plotly/workflows/build/badge.svg" alt="build status">
+    <a href="https://github.com/plotly/plotly.rs/actions?query=branch%3Amain" style="text-decoration: none!important;">
+        <img src="https://img.shields.io/github/actions/workflow/status/plotly/plotly.rs/ci.yml?branch=main" alt="Build status">
     </a>
     <a href="https://crates.io/crates/plotly">
         <img src="https://img.shields.io/crates/v/plotly.svg" alt="Crates.io">
@@ -18,26 +18,26 @@
 
 # Getting Started
 
-To start using [plotly.rs](https://github.com/igiagkiozis/plotly) in your project add the following to your `Cargo.toml`:
+To start using [plotly.rs](https://github.com/plotly/plotly.rs) in your project add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
 plotly = "0.8.4"
 ```
 
-[Plotly.rs](https://github.com/igiagkiozis/plotly) is ultimately a thin wrapper around the `plotly.js` library. The main job of this library is to provide `structs` and `enums` which get serialized to `json` and passed to the `plotly.js` library to actually do the heavy lifting. As such, if you are familiar with `plotly.js` or its derivatives (e.g. the equivalent Python library), then you should find [`plotly.rs`](https://github.com/igiagkiozis/plotly) intuitive to use.
+[Plotly.rs](https://github.com/plotly/plotly.rs) is ultimately a thin wrapper around the `plotly.js` library. The main job of this library is to provide `structs` and `enums` which get serialized to `json` and passed to the `plotly.js` library to actually do the heavy lifting. As such, if you are familiar with `plotly.js` or its derivatives (e.g. the equivalent Python library), then you should find [`plotly.rs`](https://github.com/plotly/plotly.rs) intuitive to use.
 
 A `Plot` struct contains one or more `Trace` objects which describe the structure of data to be displayed. Optional `Layout` and `Configuration` structs can be used to specify the layout and config of the plot, respectively.
 
 The builder pattern is used extensively throughout the library, which means you only need to specify the attributes and details you desire. Any attributes that are not set will fall back to the default value used by `plotly.js`.
 
-All available traces (e.g. `Scatter`, `Bar`, `Histogram`, etc), the `Layout`, `Configuration` and  `Plot` have been hoisted in the `plotly` namespace so that they can be imported simply using the following: 
+All available traces (e.g. `Scatter`, `Bar`, `Histogram`, etc), the `Layout`, `Configuration` and  `Plot` have been hoisted in the `plotly` namespace so that they can be imported simply using the following:
 
 ```rust
 use plotly::{Plot, Layout, Scatter};
 ```
 
-The aforementioned components can be combined to produce as simple plot as follows: 
+The aforementioned components can be combined to produce as simple plot as follows:
 
 ```rust
 use plotly::common::Mode;
@@ -65,17 +65,17 @@ fn main() -> std::io::Result<()> {
 }
 ```
 
-which results in the following figure (displayed here as a static png file): 
+which results in the following figure (displayed here as a static png file):
 
 ![line_and_scatter_plot](img/line_and_scatter_plot.png)
 
-The above code will generate an interactive `html` page of the `Plot` and display it in the default browser. The `html` for the plot is stored in the platform specific temporary directory. To save the `html` result, you can do so quite simply: 
+The above code will generate an interactive `html` page of the `Plot` and display it in the default browser. The `html` for the plot is stored in the platform specific temporary directory. To save the `html` result, you can do so quite simply:
 
 ```rust
 plot.write_html("/home/user/line_and_scatter_plot.html");
 ```
 
-It is often the case that plots are produced to be included in a document and a different format for the plot is desirable (e.g. png, jpeg, etc). Given that the `html` version of the plot is composed of vector graphics, the display when converted to a non-vector format (e.g. png) is not guaranteed to be identical to the one displayed in `html`. This means that some fine tuning may be required to get to the desired output. To support that iterative workflow, `Plot` has a `show_image()` method which will display the rasterised output to the target format, for example: 
+It is often the case that plots are produced to be included in a document and a different format for the plot is desirable (e.g. png, jpeg, etc). Given that the `html` version of the plot is composed of vector graphics, the display when converted to a non-vector format (e.g. png) is not guaranteed to be identical to the one displayed in `html`. This means that some fine tuning may be required to get to the desired output. To support that iterative workflow, `Plot` has a `show_image()` method which will display the rasterised output to the target format, for example:
 
 ```rust
 plot.show_image(ImageFormat::PNG, 1280, 900);
@@ -83,7 +83,7 @@ plot.show_image(ImageFormat::PNG, 1280, 900);
 
 will display in the browser the rasterised plot; 1280 pixels wide and 900 pixels tall, in png format.
 
-Once a satisfactory result is achieved, and assuming the [`kaleido`](getting_started#saving-plots) feature is enabled, the plot can be saved using the following: 
+Once a satisfactory result is achieved, and assuming the [`kaleido`](getting_started#saving-plots) feature is enabled, the plot can be saved using the following:
 
 ```rust
 plot.write_image("/home/user/plot_name.ext", ImageFormat::PNG, 1280, 900, 1.0);
@@ -93,7 +93,7 @@ The extension in the file-name path is optional as the appropriate extension (`I
 
 ## Saving Plots
 
-To add the ability to save plots in the following formats: png, jpeg, webp, svg, pdf and eps, you can use the `kaleido` feature. This feature depends on [plotly/Kaleido](https://github.com/plotly/Kaleido): a cross-platform open source library for generating static images. All the necessary binaries have been included with `plotly_kaleido` for `Linux`, `Windows` and `MacOS`. Previous versions of [plotly.rs](https://github.com/igiagkiozis/plotly) used the `orca` feature, however, this has been deprecated as it provided the same functionality but required additional installation steps. To enable the `kaleido` feature add the following to your `Cargo.toml`: 
+To add the ability to save plots in the following formats: png, jpeg, webp, svg, pdf and eps, you can use the `kaleido` feature. This feature depends on [plotly/Kaleido](https://github.com/plotly/Kaleido): a cross-platform open source library for generating static images. All the necessary binaries have been included with `plotly_kaleido` for `Linux`, `Windows` and `MacOS`. Previous versions of [plotly.rs](https://github.com/plotly/plotly.rs) used the `orca` feature, however, this has been deprecated as it provided the same functionality but required additional installation steps. To enable the `kaleido` feature add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
@@ -102,7 +102,7 @@ plotly = { version = "0.8.4", features = ["kaleido"] }
 
 ## WebAssembly Support
 
-As of v0.8.0, [plotly.rs](https://github.com/igiagkiozis/plotly) can now be used in a `Wasm` environment by enabling the `wasm` feature in your `Cargo.toml`:
+As of v0.8.0, [plotly.rs](https://github.com/plotly/plotly.rs) can now be used in a `Wasm` environment by enabling the `wasm` feature in your `Cargo.toml`:
 
 ```toml
 [dependencies]

--- a/docs/book/src/plotly_rs.md
+++ b/docs/book/src/plotly_rs.md
@@ -1,9 +1,9 @@
 <div align="center">
-    <a href="https://github.com/igiagkiozis/plotly/tree/master">
-        <img src="https://img.shields.io/badge/Plotly.rs-master-brightgreen" alt="build status">
+    <a href="https://github.com/plotly/plotly.rs/tree/main">
+        <img src="https://img.shields.io/badge/Plotly.rs-main-brightgreen" alt="build status">
     </a>
-    <a href="https://github.com/igiagkiozis/plotly/actions">
-        <img src="https://github.com/igiagkiozis/plotly/workflows/build/badge.svg" alt="build status">
+    <a href="https://github.com/plotly/plotly.rs/actions?query=branch%3Amain" style="text-decoration: none!important;">
+        <img src="https://img.shields.io/github/actions/workflow/status/plotly/plotly.rs/ci.yml?branch=main" alt="Build status">
     </a>
     <a href="https://crates.io/crates/plotly">
         <img src="https://img.shields.io/crates/v/plotly.svg" alt="Crates.io">
@@ -20,17 +20,17 @@
 
 Plotly.rs is a plotting library powered by [Plotly.js](https://plot.ly/javascript/). The aim is to bring over to Rust all the functionality that `Python` users have come to rely on with the added benefit of type safety and speed.
 
-Plotly.rs is free and open source. You can find the source on [GitHub](https://github.com/igiagkiozis/plotly). Issues and feature requests can be posted on the [issue tracker](https://github.com/igiagkiozis/plotly/issues).
+Plotly.rs is free and open source. You can find the source on [GitHub](https://github.com/plotly/plotly.rs). Issues and feature requests can be posted on the [issue tracker](https://github.com/plotly/plotly.rs/issues).
 
 ## API Docs
 
 This book is intended to be a recipe index, which closely follows the [plotly.js examples](https://plotly.com/javascript/), and is complemented by the [API documentation](https://docs.rs/plotly).
 
 ## Contributing
-Contributions are always welcomed, no matter how large or small. Refer to the [contributing guidelines](https://github.com/igiagkiozis/plotly/blob/master/CONTRIBUTING.md) for further pointers, and, if in doubt, [open an issue](https://github.com/igiagkiozis/plotly/issues).
+Contributions are always welcomed, no matter how large or small. Refer to the [contributing guidelines](https://github.com/plotly/plotly.rs/tree/main/CONTRIBUTING.md) for further pointers, and, if in doubt, [open an issue](https://github.com/plotly/plotly.rs/issues).
 
 ## License
 
 Plotly.rs is distributed under the terms of the MIT license.
 
-See [LICENSE-MIT](https://github.com/igiagkiozis/plotly/blob/master/LICENSE-MIT), and [COPYRIGHT](https://github.com/igiagkiozis/plotly/blob/master/COPYRIGHT) for details.
+See [LICENSE-MIT](https://github.com/plotly/plotly.rs/tree/main/LICENSE-MIT), and [COPYRIGHT](https://github.com/plotly/plotly.rs/tree/main/COPYRIGHT) for details.

--- a/docs/book/src/recipes.md
+++ b/docs/book/src/recipes.md
@@ -1,9 +1,9 @@
 <div align="center">
-    <a href="https://github.com/igiagkiozis/plotly/tree/master">
-        <img src="https://img.shields.io/badge/Plotly.rs-master-brightgreen" alt="build status">
+    <a href="https://github.com/plotly/plotly.rs/tree/main">
+        <img src="https://img.shields.io/badge/Plotly.rs-main-brightgreen" alt="build status">
     </a>
-    <a href="https://github.com/igiagkiozis/plotly/actions">
-        <img src="https://github.com/igiagkiozis/plotly/workflows/build/badge.svg" alt="build status">
+    <a href="https://github.com/plotly/plotly.rs/actions?query=branch%3Amain" style="text-decoration: none!important;">
+        <img src="https://img.shields.io/github/actions/workflow/status/plotly/plotly.rs/ci.yml?branch=main" alt="Build status">
     </a>
     <a href="https://crates.io/crates/plotly">
         <img src="https://img.shields.io/crates/v/plotly.svg" alt="Crates.io">
@@ -18,4 +18,4 @@
 
 # Recipes
 
-Most of the recipes presented here have been adapted from the official documentation for [plotly.js](https://plotly.com/javascript/) and [plotly.py](https://plotly.com/python/). Contributions of interesting plots that showcase the capabilities of the library are most welcome. For more information on the process please see [the contributing guidelines](https://github.com/igiagkiozis/plotly/blob/master/CONTRIBUTING.md).
+Most of the recipes presented here have been adapted from the official documentation for [plotly.js](https://plotly.com/javascript/) and [plotly.py](https://plotly.com/python/). Contributions of interesting plots that showcase the capabilities of the library are most welcome. For more information on the process please see [the contributing guidelines](https://github.com/plotly/plotly.rs/tree/main/CONTRIBUTING.md).

--- a/docs/book/src/recipes/3dcharts.md
+++ b/docs/book/src/recipes/3dcharts.md
@@ -1,6 +1,6 @@
 # 3D Charts
 
-The complete source code for the following examples can also be found [here](https://github.com/igiagkiozis/plotly/blob/master/plotly/examples/plot3d.rs).
+The complete source code for the following examples can also be found [here](https://github.com/plotly/plotly.rs/tree/main/examples/plot3d).
 
 Kind | Link
 :---|:----:

--- a/docs/book/src/recipes/basic_charts.md
+++ b/docs/book/src/recipes/basic_charts.md
@@ -1,6 +1,6 @@
 # Basic Charts
 
-The source code for the following examples can also be found [here](https://github.com/igiagkiozis/plotly/blob/master/plotly/examples/basic_charts.rs).
+The source code for the following examples can also be found [here](https://github.com/plotly/plotly.rs/tree/main/examples/basic_charts).
 
 Kind | Link
 :---|:----:

--- a/docs/book/src/recipes/financial_charts.md
+++ b/docs/book/src/recipes/financial_charts.md
@@ -1,6 +1,6 @@
 # Financial Charts
 
-The source code for the following examples can also be found [here](https://github.com/igiagkiozis/plotly/blob/master/plotly/examples/financial_charts.rs).
+The source code for the following examples can also be found [here](https://github.com/plotly/plotly.rs/tree/main/examples/financial_charts).
 
 Kind | Link
 :---|:----:

--- a/docs/book/src/recipes/scientific_charts.md
+++ b/docs/book/src/recipes/scientific_charts.md
@@ -1,6 +1,6 @@
 # Scientific Charts
 
-The source code for the following examples can also be found [here](https://github.com/igiagkiozis/plotly/blob/master/plotly/examples/scientific_charts.rs).
+The source code for the following examples can also be found [here](https://github.com/plotly/plotly.rs/tree/main/examples/scientific_charts).
 
 Kind | Link
 :---|:----:

--- a/docs/book/src/recipes/statistical_charts.md
+++ b/docs/book/src/recipes/statistical_charts.md
@@ -1,6 +1,6 @@
 # Statistical Charts
 
-The complete source code for the following examples can also be found [here](https://github.com/igiagkiozis/plotly/blob/master/plotly/examples/statistical_charts.rs).
+The complete source code for the following examples can also be found [here](https://github.com/plotly/plotly.rs/tree/main/examples/statistical_charts).
 
 Kind | Link
 :---|:----:

--- a/docs/book/src/recipes/subplots.md
+++ b/docs/book/src/recipes/subplots.md
@@ -1,6 +1,6 @@
 # Subplots
 
-The complete source code for the following examples can also be found [here](https://github.com/igiagkiozis/plotly/blob/master/plotly/examples/subplots.rs).
+The complete source code for the following examples can also be found [here](https://github.com/plotly/plotly.rs/tree/main/examples/subplots).
 
 Kind | Link
 :---|:----:

--- a/plotly/Cargo.toml
+++ b/plotly/Cargo.toml
@@ -5,9 +5,9 @@ description = "A plotting library powered by Plotly.js"
 authors = ["Ioannis Giagkiozis <i.giagkiozis@gmail.com>"]
 license = "MIT"
 readme = "../README.md"
-homepage = "https://github.com/igiagkiozis/plotly"
+homepage = "https://github.com/plotly/plotly.rs"
 documentation = "https://docs.rs/plotly"
-repository = "https://github.com/igiagkiozis/plotly"
+repository = "https://github.com/plotly/plotly.rs"
 edition = "2018"
 keywords = ["plot", "chart", "plotly"]
 

--- a/plotly/src/plot.rs
+++ b/plotly/src/plot.rs
@@ -62,7 +62,7 @@ let height = 680;
 let scale = 1.0;
 plot.write_image("filename", ImageFormat::PNG, width, height, scale);
 
-See https://igiagkiozis.github.io/plotly/content/getting_started.html for further details.
+See https://plotly.github.io/plotly.rs/content/getting_started.html for further details.
 "#;
 
 /// Image format for static image export.

--- a/plotly_derive/Cargo.toml
+++ b/plotly_derive/Cargo.toml
@@ -4,9 +4,9 @@ version = "0.8.4"
 description = "Internal proc macro crate for Plotly-rs."
 authors = ["Ioannis Giagkiozis <i.giagkiozis@gmail.com>"]
 license = "MIT"
-homepage = "https://github.com/igiagkiozis/plotly"
+homepage = "https://github.com/plotly/plotly.rs"
 documentation = "https://docs.rs/plotly"
-repository = "https://github.com/igiagkiozis/plotly"
+repository = "https://github.com/plotly/plotly.rs"
 edition = "2018"
 keywords = ["plot", "chart", "plotly"]
 

--- a/plotly_derive/README.md
+++ b/plotly_derive/README.md
@@ -1,3 +1,3 @@
 # plotly_derive
 
-This is an internal crate defining procedural macros for [Plotly.rs](https://github.com/igiagkiozis/plotly).
+This is an internal crate defining procedural macros for [Plotly.rs](https://github.com/plotly/plotly.rs).

--- a/plotly_kaleido/Cargo.toml
+++ b/plotly_kaleido/Cargo.toml
@@ -6,9 +6,9 @@ authors = ["Ioannis Giagkiozis <i.giagkiozis@gmail.com>"]
 license = "MIT"
 readme = "README.md"
 workspace = ".."
-homepage = "https://github.com/igiagkiozis/plotly"
+homepage = "https://github.com/plotly/plotly.rs"
 documentation = "https://docs.rs/plotly_kaleido"
-repository = "https://github.com/igiagkiozis/plotly"
+repository = "https://github.com/plotly/plotly.rs"
 edition = "2018"
 keywords = ["plot", "chart", "plotly", "ndarray"]
 

--- a/plotly_kaleido/README.md
+++ b/plotly_kaleido/README.md
@@ -1,7 +1,7 @@
 # plotly_kaleido
 
-This is an internal crate which implements the `kaleido` feature for [Plotly.rs](https://github.com/igiagkiozis/plotly).
- 
-The `kaleido` feature enables `Plot` conversion to the following output formats: `png`, `jpeg`, `webp`, `svg`, `pdf` and `eps`. 
+This is an internal crate which implements the `kaleido` feature for [Plotly.rs](https://github.com/plotly/plotly.rs).
 
-See [examples/](https://github.com/igiagkiozis/plotly/tree/master/examples/kaleido) for usage demonstrations.
+The `kaleido` feature enables `Plot` conversion to the following output formats: `png`, `jpeg`, `webp`, `svg`, `pdf` and `eps`.
+
+See [examples/](https://github.com/plotly/plotly.rs/tree/main/examples/kaleido) for usage demonstrations.

--- a/plotly_kaleido/src/lib.rs
+++ b/plotly_kaleido/src/lib.rs
@@ -1,5 +1,5 @@
 //! # Plotly Kaleido
-//! Plotly Kaleido implements the `kaleido` feature for [Plotly.rs](https://github.com/igiagkiozis/plotly)
+//! Plotly Kaleido implements the `kaleido` feature for [Plotly.rs](https://github.com/plotly/plotly.rs)
 //!
 //! The `kaleido` feature enables `Plot` conversion to the following output
 //! formats: png, jpeg, webp, svg, pdf and eps. It has the added benefit over


### PR DESCRIPTION
 - change references from `master` to `main` branch
 - change hyperlinks throught the repo to point to new repository url
 - similarly, fix the hyperlinks in the Rust book