### PR TITLE
Switch from askama to rinja

### DIFF
--- a/plotly/Cargo.toml
+++ b/plotly/Cargo.toml
@@ -18,11 +18,11 @@ kaleido = ["plotly_kaleido"]
 plotly_ndarray = ["ndarray"]
 plotly_image = ["image"]
 wasm = ["getrandom", "js-sys", "wasm-bindgen", "wasm-bindgen-futures"]
-with-axum = ["askama/with-axum", "askama_axum"]
+with-axum = ["rinja/with-axum", "rinja_axum"]
 
 [dependencies]
-askama = { version = ">=0.11.0, <0.13.0", features = ["serde-json"] }
-askama_axum = { version = "0.4.0", optional = true }
+rinja = { version = "0.3", features = ["serde_json"] }
+rinja_axum = { version = "0.3.0", optional = true }
 dyn-clone = "1"
 erased-serde = "0.4"
 getrandom = { version = "0.2", features = ["js"], optional = true }

--- a/plotly/src/lib.rs
+++ b/plotly/src/lib.rs
@@ -2,8 +2,8 @@
 //!
 //! A plotting library for Rust powered by [Plotly.js](https://plot.ly/javascript/).
 #![recursion_limit = "256"] // lets us use a large serde_json::json! macro for testing crate::layout::Axis
-extern crate askama;
 extern crate rand;
+extern crate rinja;
 extern crate serde;
 
 #[cfg(all(feature = "kaleido", feature = "wasm"))]

--- a/plotly/src/plot.rs
+++ b/plotly/src/plot.rs
@@ -1,12 +1,12 @@
 use std::{fs::File, io::Write, path::Path};
 
-use askama::Template;
 use dyn_clone::DynClone;
 use erased_serde::Serialize as ErasedSerialize;
 use rand::{
     distributions::{Alphanumeric, DistString},
     thread_rng,
 };
+use rinja::Template;
 use serde::Serialize;
 
 use crate::{Configuration, Layout};


### PR DESCRIPTION
Recently, me and another `askama` maintainer forked the project into `rinja`. For more details about the why, I wrote a blog post [here](https://blog.guillaume-gomez.fr/articles/2024-07-31+docs.rs+switching+jinja+template+framework+from+tera+to+rinja). But in short: `rinja` is ahead of `askama` now in a lot of areas so I think going forward, your project will benefit more from it.

If you're not interested about this switch, don't hesitate to close the PR.

If you want more information about `rinja`, don't hesitate to ask!