### PR TITLE
Generalize OS detection.

### DIFF
--- a/plotly/src/plot.rs
+++ b/plotly/src/plot.rs
@@ -464,7 +464,7 @@ impl Plot {
             .expect("Invalid JSON structure - expected a top-level Object")
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(all(unix, not(target_os = "android"), not(target_os = "macos")))]
     fn show_with_default_app(temp_path: &str) {
         use std::process::Command;
         Command::new("xdg-open")


### PR DESCRIPTION
There are many Unix-like OSes that have xdg-open that are not Linux. Rather than enumerating DragonflyBSD, FreeBSD, NetBSD, OpenBSD, etc., change this "Linux" target to "Unix and not Android and not MacOS".