### PR TITLE
Examples: fix swapped x and y

### DIFF
--- a/examples/3d_charts/src/main.rs
+++ b/examples/3d_charts/src/main.rs
@@ -130,10 +130,10 @@ fn surface_plot() {
     let n: usize = 100;
     let x: Vec<f64> = Array::linspace(-10., 10., n).into_raw_vec_and_offset().0;
     let y: Vec<f64> = Array::linspace(-10., 10., n).into_raw_vec_and_offset().0;
-    let z: Vec<Vec<f64>> = x
+    let z: Vec<Vec<f64>> = y
         .iter()
         .map(|i| {
-            y.iter()
+            x.iter()
                 .map(|j| 1.0 / (j * j + 5.0) * j.sin() + 1.0 / (i * i + 5.0) * i.cos())
                 .collect()
         })

--- a/examples/scientific_charts/src/main.rs
+++ b/examples/scientific_charts/src/main.rs
@@ -19,9 +19,9 @@ fn simple_contour_plot() {
         y.push(value);
     }
 
-    x.iter().take(n).for_each(|x| {
+    y.iter().take(n).for_each(|y| {
         let mut row = Vec::<f64>::new();
-        y.iter().take(n).for_each(|y| {
+        x.iter().take(n).for_each(|x| {
             let radius_squared = x.powf(2.0) + y.powf(2.0);
             let zv = x.sin() * y.cos() * radius_squared.sin() / (radius_squared + 1.0).log10();
             row.push(zv);
@@ -112,11 +112,11 @@ fn basic_heat_map() {
 fn customized_heat_map() {
     let x = (0..100).map(|x| x as f64).collect::<Vec<f64>>();
     let y = (0..100).map(|y| y as f64).collect::<Vec<f64>>();
-    let z: Vec<Vec<f64>> = x
+    let z: Vec<Vec<f64>> = y
         .iter()
-        .map(|x| {
-            y.iter()
-                .map(|y| (x / 5.0).powf(2.0) + (y / 5.0).powf(2.0))
+        .map(|y| {
+            x.iter()
+                .map(|x| (x / 5.0).powf(2.0) + (y / 5.0).powf(2.0))
                 .collect::<Vec<f64>>()
         })
         .collect::<Vec<Vec<f64>>>();


### PR DESCRIPTION
In the examples of contour, surface, and heatmap plots, the names `x` and `y` in the code were swapped.
Using the examples as a starting point thus yielded flipped results.
This is only a naming issue, the functionality is left unchanged.