### PR TITLE
Change Contours size to be `f64` instead of `usize`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 2024-11-x
+### Changed
+- [[#245](https://github.com/plotly/plotly.rs/pull/245)] Change Contours size to be `f64` instead of `usize`
+
 ## [0.10.1] - 2024-11-x
 ### Added
 - [[#243](https://github.com/plotly/plotly.rs/pull/243)] Made `plotly_embed_js` embed all JS scripts when enabled. 

--- a/docs/book/src/recipes/scientific_charts/contour_plots.md
+++ b/docs/book/src/recipes/scientific_charts/contour_plots.md
@@ -113,7 +113,7 @@ fn customizing_size_and_range_of_a_contour_plots_contours(show: bool) {
     let trace = Contour::new_z(z)
         .color_scale(ColorScale::Palette(ColorScalePalette::Jet))
         .auto_contour(false)
-        .contours(Contours::new().start(0.0).end(8.0).size(2));
+        .contours(Contours::new().start(0.0).end(8.0).size(2.0));
 
     let layout = Layout::new().title(Title::with_text("Customizing Size and Range of Contours"));
     let mut plot = Plot::new();
@@ -136,7 +136,7 @@ fn customizing_size_and_range_of_a_contour_plots_contours(show: bool) {
     if (document.getElementById("customizing_size_and_range_of_a_contour_plots_contours")) {
         var d3 = Plotly.d3;
         var image_element= d3.select('#image-export');
-        var trace_0 = {"type":"contour","z":[[10.0,10.625,12.5,15.625,20.0],[5.625,6.25,8.125,11.25,15.625],[2.5,3.125,5.0,8.125,12.5],[0.625,1.25,3.125,6.25,10.625],[0.0,0.625,2.5,5.625,10.0]],"colorscale":"Jet","autocontour":false,"contours":{"start":0.0,"end":8.0,"size":2}};
+        var trace_0 = {"type":"contour","z":[[10.0,10.625,12.5,15.625,20.0],[5.625,6.25,8.125,11.25,15.625],[2.5,3.125,5.0,8.125,12.5],[0.625,1.25,3.125,6.25,10.625],[0.0,0.625,2.5,5.625,10.0]],"colorscale":"Jet","autocontour":false,"contours":{"start":0.0,"end":8.0,"size":2.0}};
 var data = [trace_0];
 var layout = {"title":{"text":"Customizing Size and Range of Contours"}};
         Plotly.newPlot('customizing_size_and_range_of_a_contour_plots_contours', data, layout, {"responsive": true});

--- a/examples/scientific_charts/src/main.rs
+++ b/examples/scientific_charts/src/main.rs
@@ -66,7 +66,7 @@ fn customizing_size_and_range_of_a_contour_plots_contours() {
     let trace = Contour::new_z(z)
         .color_scale(ColorScale::Palette(ColorScalePalette::Jet))
         .auto_contour(false)
-        .contours(Contours::new().start(0.0).end(8.0).size(2));
+        .contours(Contours::new().start(0.0).end(8.0).size(2.0));
 
     let layout = Layout::new().title("Customizing Size and Range of Contours");
     let mut plot = Plot::new();

--- a/plotly/src/traces/contour.rs
+++ b/plotly/src/traces/contour.rs
@@ -53,7 +53,7 @@ pub struct Contours {
     r#type: Option<ContoursType>,
     start: Option<f64>,
     end: Option<f64>,
-    size: Option<usize>,
+    size: Option<f64>,
     coloring: Option<Coloring>,
     #[serde(rename = "showlines")]
     show_lines: Option<bool>,
@@ -522,7 +522,7 @@ mod tests {
             .type_(ContoursType::Levels)
             .start(0.0)
             .end(10.0)
-            .size(5)
+            .size(5.0)
             .coloring(Coloring::HeatMap)
             .show_lines(true)
             .show_labels(false)
@@ -535,7 +535,7 @@ mod tests {
             "type": "levels",
             "start": 0.0,
             "end": 10.0,
-            "size": 5,
+            "size": 5.0,
             "coloring": "heatmap",
             "showlines": true,
             "showlabels": false,


### PR DESCRIPTION
Without this, the intervals between contour lines can only be integers.
I needed a smaller interval for a figure.

To Do:
- [x] Update changelog