### PR TITLE
Fix broken links and incorrect graphs in book

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: cargo install mdbook
+      - run: cargo install mdbook --no-default-features --features search --vers "^0.4" --locked --quiet
       - name: Build examples
         run: |
           cd ${{ github.workspace }}/examples/basic_charts && cargo run
@@ -40,5 +40,9 @@ jobs:
             git config --global user.email 'github-actions[bot]@users.noreply.github.com'
             
             git add content
-            git commit --allow-empty -m 'Deploy to GitHub Pages'
+            if [ "${{ github.ref_type }}" == "tag" ]; then
+              git commit --allow-empty -m "update book for release ${{ github.ref }}"
+            else
+              git commit --allow-empty -m 'update book from commit ${{ github.sha }}'
+            fi
             git push origin gh-pages

--- a/docs/book/src/fundamentals/ndarray_support.md
+++ b/docs/book/src/fundamentals/ndarray_support.md
@@ -10,7 +10,7 @@ This extends the [Plotly.rs](https://github.com/plotly/plotly.rs) API in two way
 * `Scatter` traces can now be created using the `Scatter::from_ndarray` constructor,
 * and also multiple traces can be created with the `Scatter::to_traces` method.
 
-The full source code for the examples below can be found [here](https://github.com/plotly/plotly.rs/tree/main/examples/ndarray_support).
+The full source code for the examples below can be found [here](https://github.com/plotly/plotly.rs/tree/main/examples/ndarray).
 
 ## `ndarray` Traces
 

--- a/docs/book/src/getting_started.md
+++ b/docs/book/src/getting_started.md
@@ -83,7 +83,7 @@ plot.show_image(ImageFormat::PNG, 1280, 900);
 
 will display in the browser the rasterised plot; 1280 pixels wide and 900 pixels tall, in png format.
 
-Once a satisfactory result is achieved, and assuming the [`kaleido`](getting_started#saving-plots) feature is enabled, the plot can be saved using the following:
+Once a satisfactory result is achieved, and assuming the [`kaleido`](#saving-plots) feature is enabled, the plot can be saved using the following:
 
 ```rust
 plot.write_image("/home/user/plot_name.ext", ImageFormat::PNG, 1280, 900, 1.0);

--- a/docs/book/src/plotly_rs.md
+++ b/docs/book/src/plotly_rs.md
@@ -33,4 +33,4 @@ Contributions are always welcomed, no matter how large or small. Refer to the [c
 
 Plotly.rs is distributed under the terms of the MIT license.
 
-See [LICENSE-MIT](https://github.com/plotly/plotly.rs/tree/main/LICENSE-MIT), and [COPYRIGHT](https://github.com/plotly/plotly.rs/tree/main/COPYRIGHT) for details.
+See [LICENSE](https://github.com/plotly/plotly.rs/tree/main/LICENSE)

--- a/docs/book/src/recipes/3dcharts.md
+++ b/docs/book/src/recipes/3dcharts.md
@@ -1,6 +1,6 @@
 # 3D Charts
 
-The complete source code for the following examples can also be found [here](https://github.com/plotly/plotly.rs/tree/main/examples/plot3d).
+The complete source code for the following examples can also be found [here](https://github.com/plotly/plotly.rs/tree/main/examples/3d_charts).
 
 Kind | Link
 :---|:----:

--- a/examples/statistical_charts/src/main.rs
+++ b/examples/statistical_charts/src/main.rs
@@ -214,12 +214,19 @@ fn box_plot_that_displays_the_underlying_data(show: bool) -> Plot {
 
 // ANCHOR: horizontal_box_plot
 fn horizontal_box_plot(show: bool) -> Plot {
-    let trace1 = BoxPlot::new(vec![1, 2, 3, 4, 4, 4, 8, 9, 10]).name("Set 1");
-    let trace2 = BoxPlot::new(vec![2, 3, 3, 3, 3, 5, 6, 6, 7]).name("Set 2");
+    let x = vec![
+        "Set 1", "Set 1", "Set 1", "Set 1", "Set 1", "Set 1", "Set 1", "Set 1", "Set 1", "Set 2",
+        "Set 2", "Set 2", "Set 2", "Set 2", "Set 2", "Set 2", "Set 2", "Set 2",
+    ];
+
+    let trace = BoxPlot::new_xy(
+        vec![1, 2, 3, 4, 4, 4, 8, 9, 10, 2, 3, 3, 3, 3, 5, 6, 6, 7],
+        x.clone(),
+    )
+    .orientation(Orientation::Horizontal);
 
     let mut plot = Plot::new();
-    plot.add_trace(trace1);
-    plot.add_trace(trace2);
+    plot.add_trace(trace);
 
     if show {
         plot.show();


### PR DESCRIPTION
Fixes #248 

* Updated mdbook install command based on the recommended CI command (saves around 30seconds build time)
* Included git tag in the commit message to the gh-pages branch
* Fixed some broken links
* Fixed horizontal box plot example which was producing a vertical plot