### PR TITLE
Make i, j, k optional

### DIFF
--- a/examples/3d_charts/src/main.rs
+++ b/examples/3d_charts/src/main.rs
@@ -172,9 +172,9 @@ fn mesh_3d_plot(show: bool) -> Plot {
         vec![0, 1, 2, 0],
         vec![0, 0, 1, 2],
         vec![0, 2, 0, 1],
-        vec![0, 0, 0, 1],
-        vec![1, 2, 3, 2],
-        vec![2, 3, 1, 3],
+        Some(vec![0, 0, 0, 1]),
+        Some(vec![1, 2, 3, 2]),
+        Some(vec![2, 3, 1, 3]),
     )
     .intensity(vec![0.0, 0.33, 0.66, 1.0])
     .color_scale(ColorScale::Palette(ColorScalePalette::Rainbow));

--- a/plotly/src/traces/mesh3d.rs
+++ b/plotly/src/traces/mesh3d.rs
@@ -389,17 +389,17 @@ where
         x: Vec<X>,
         y: Vec<Y>,
         z: Vec<Z>,
-        i: Vec<usize>,
-        j: Vec<usize>,
-        k: Vec<usize>,
+        i: Option<Vec<usize>>,
+        j: Option<Vec<usize>>,
+        k: Option<Vec<usize>>,
     ) -> Box<Self> {
         Box::new(Self {
             x: Some(x),
             y: Some(y),
             z: Some(z),
-            i: Some(i),
-            j: Some(j),
-            k: Some(k),
+            i,
+            j,
+            k,
             ..Default::default()
         })
     }
@@ -484,9 +484,9 @@ mod tests {
             vec![0.0, 1.0, 2.0],
             vec![3.0, 4.0, 5.0],
             vec![6.0, 7.0, 8.0],
-            vec![0],
-            vec![1],
-            vec![2],
+            Some(vec![0]),
+            Some(vec![1]),
+            Some(vec![2]),
         )
         .name("trace_name")
         .visible(Visible::True)


### PR DESCRIPTION
Fixes https://github.com/plotly/plotly.rs/issues/259.

I'm happy to make this a new function that only requires x, y, & z but it feels like that should be named `new` and another name should be used when providing i, j, & k.