### PR TITLE
chore: use last version of use_effect_with in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,11 +182,10 @@ pub fn plot_component() -> Html {
     });
 
 
-        use_effect_with_deps(move |_| {
-            p.run();
-            || ()
-        }, (),
-    );
+    use_effect_with((), move |_| {
+        p.run();
+        || ()
+    });
 
 
     html! {


### PR DESCRIPTION
In the README.md, in the section _Usage Within a Wasm Environment_, I simply use `use_effect_with` instead of `use_effect_with_deps` which is deprecated in last Yew versions.