### PR TITLE
Update to askama 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.13.0] - 2025-02-xx
+## [0.13.0] - 2025-03-xx
 ### Changed
 - [[#277](https://github.com/plotly/plotly.rs/pull/277)] Removed `wasm` feature flag and put evrything behind target specific dependencies. Added `.cargo/config.toml` for configuration flags needed by `getrandom` version 0.3 on `wasm` targets.
+- [[#281]((https://github.com/plotly/plotly.rs/pull/xxx))] Update to askama 0.13.0
 
 ## [0.12.1] - 2025-01-02
 ### Fixed

--- a/plotly/Cargo.toml
+++ b/plotly/Cargo.toml
@@ -21,11 +21,8 @@ plotly_ndarray = ["ndarray"]
 plotly_image = ["image"]
 plotly_embed_js = []
 
-with-axum = ["rinja/with-axum", "rinja_axum"]
-
 [dependencies]
-rinja = { version = "0.3", features = ["serde_json"] }
-rinja_axum = { version = "0.3", optional = true }
+askama = { version = "0.13.0", features = ["serde_json"] }
 dyn-clone = "1"
 erased-serde = "0.4"
 image = { version = "0.25", optional = true }

--- a/plotly/src/lib.rs
+++ b/plotly/src/lib.rs
@@ -2,8 +2,8 @@
 //!
 //! A plotting library for Rust powered by [Plotly.js](https://plot.ly/javascript/).
 #![recursion_limit = "256"] // lets us use a large serde_json::json! macro for testing crate::layout::Axis
+extern crate askama;
 extern crate rand;
-extern crate rinja;
 extern crate serde;
 
 #[cfg(all(feature = "kaleido", target_family = "wasm"))]

--- a/plotly/src/plot.rs
+++ b/plotly/src/plot.rs
@@ -15,7 +15,7 @@ use crate::{Configuration, Layout};
 #[template(path = "plot.html", escape = "none")]
 struct PlotTemplate<'a> {
     plot: &'a Plot,
-    js_scripts: String,
+    js_scripts: &'a str,
 }
 
 #[derive(Template)]
@@ -24,7 +24,7 @@ struct PlotTemplate<'a> {
 struct StaticPlotTemplate<'a> {
     plot: &'a Plot,
     format: ImageFormat,
-    js_scripts: String,
+    js_scripts: &'a str,
     width: usize,
     height: usize,
 }
@@ -466,7 +466,7 @@ impl Plot {
     fn render(&self) -> String {
         let tmpl = PlotTemplate {
             plot: self,
-            js_scripts: self.js_scripts.clone(),
+            js_scripts: &self.js_scripts,
         };
         tmpl.render().unwrap()
     }
@@ -476,7 +476,7 @@ impl Plot {
         let tmpl = StaticPlotTemplate {
             plot: self,
             format,
-            js_scripts: self.js_scripts.clone(),
+            js_scripts: &self.js_scripts,
             width,
             height,
         };

--- a/plotly/src/plot.rs
+++ b/plotly/src/plot.rs
@@ -1,12 +1,12 @@
 use std::{fs::File, io::Write, path::Path};
 
+use askama::Template;
 use dyn_clone::DynClone;
 use erased_serde::Serialize as ErasedSerialize;
 use rand::{
     distr::{Alphanumeric, SampleString},
     rng,
 };
-use rinja::Template;
 use serde::Serialize;
 
 use crate::{Configuration, Layout};


### PR DESCRIPTION
Rinja 0.2 was a fork of askama 0.12. Both projects were [merged again], and new versions of the project will be released under the name askama.

The feature `"with-axum"` is not needed anymore. The implementation for web-framework integrations was moved into its own crate. The `askama` crate does not have any problems with feature flag incompatibilities anymore.

[merged again]: <https://blog.guillaume-gomez.fr/articles/2025-03-19+Askama+and+Rinja+merge>