### PR TITLE
allow plotly to be compiled for android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - [[#277](https://github.com/plotly/plotly.rs/pull/277)] Removed `wasm` feature flag and put evrything behind target specific dependencies. Added `.cargo/config.toml` for configuration flags needed by `getrandom` version 0.3 on `wasm` targets.
 - [[#281]((https://github.com/plotly/plotly.rs/pull/xxx))] Update to askama 0.13.0
 
+### Fixed
+- [[#284](https://github.com/plotly/plotly.rs/pull/284)]  Allow plotly package to be compiled for android 
+
 ## [0.12.1] - 2025-01-02
 ### Fixed
 - [[#269](https://github.com/plotly/plotly.rs/pull/269)] Fix publishing to crates.io issue

--- a/plotly/src/plot.rs
+++ b/plotly/src/plot.rs
@@ -20,7 +20,7 @@ struct PlotTemplate<'a> {
 
 #[derive(Template)]
 #[template(path = "static_plot.html", escape = "none")]
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), not(target_os = "android")))]
 struct StaticPlotTemplate<'a> {
     plot: &'a Plot,
     format: ImageFormat,
@@ -43,7 +43,7 @@ struct JupyterNotebookPlotTemplate<'a> {
     plot_div_id: &'a str,
 }
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), not(target_os = "android")))]
 const DEFAULT_HTML_APP_NOT_FOUND: &str = r#"Could not find default application for HTML files.
 Consider using the `to_html` method obtain a string representation instead. If using the `kaleido` feature the
 `write_image` method can be used to produce a static image in one of the following formats:
@@ -246,7 +246,7 @@ impl Plot {
     ///
     /// The HTML file is saved in a temp file, from which it is read and
     /// displayed by the browser.
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(all(not(target_family = "wasm"), not(target_os = "android")))]
     pub fn show(&self) {
         use std::env;
 
@@ -278,7 +278,7 @@ impl Plot {
     /// The HTML file is generated and saved in the provided filename as long as
     /// the path already exists, after the file is saved, it is read and
     /// displayed by the browser.
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(all(not(target_family = "wasm"), not(target_os = "android")))]
     pub fn show_html<P: AsRef<Path> + std::clone::Clone>(&self, filename: P) {
         let path = filename.as_ref().to_str().unwrap();
         self.write_html(filename.clone());
@@ -288,7 +288,7 @@ impl Plot {
 
     /// Display the fully rendered `Plot` as a static image of the given format
     /// in the default system browser.
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(all(not(target_family = "wasm"), not(target_os = "android")))]
     pub fn show_image(&self, format: ImageFormat, width: usize, height: usize) {
         use std::env;
 
@@ -471,7 +471,7 @@ impl Plot {
         tmpl.render().unwrap()
     }
 
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(all(not(target_family = "wasm"), not(target_os = "android")))]
     fn render_static(&self, format: ImageFormat, width: usize, height: usize) -> String {
         let tmpl = StaticPlotTemplate {
             plot: self,


### PR DESCRIPTION
 - disable show/render functionality when target_os is android
 
Closes #282 