### PR TITLE
#241 Add macOS-specific fixes and tests for Kaleido compatibility

### DIFF
--- a/plotly/src/plot.rs
+++ b/plotly/src/plot.rs
@@ -584,13 +584,14 @@ impl PartialEq for Plot {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::Scatter;
+    use std::path::PathBuf;
 
     use serde_json::{json, to_value};
-    use std::path::PathBuf;
     #[cfg(not(target_os = "macos"))]
     use {base64::engine::general_purpose, base64::Engine};
+
+    use super::*;
+    use crate::Scatter;
 
     fn create_test_plot() -> Plot {
         let trace1 = Scatter::new(vec![0, 1, 2], vec![6, 10, 2]).name("trace1");

--- a/plotly/src/plot.rs
+++ b/plotly/src/plot.rs
@@ -586,8 +586,7 @@ impl PartialEq for Plot {
 mod tests {
     use std::path::PathBuf;
 
-    #[cfg(feature = "kaleido")]
-    use base64::{engine::general_purpose, Engine as _};
+
     use serde_json::{json, to_value};
 
     use super::*;
@@ -865,5 +864,32 @@ mod tests {
         // seem to contain uniquely generated IDs
         const LEN: usize = 10;
         assert_eq!(expected[..LEN], image_svg[..LEN]);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[cfg(feature = "kaleido")]
+    fn save_surface_to_png() {
+        use crate::Surface;
+        let mut plot = Plot::new();
+        let z_matrix = vec![
+            vec![1.0, 2.0, 3.0],
+            vec![4.0, 5.0, 6.0],
+            vec![7.0, 8.0, 9.0],
+        ];
+        let x_unique = vec![1.0, 2.0, 3.0];
+        let y_unique = vec![4.0, 5.0, 6.0];
+        let surface = Surface::new(z_matrix)
+            .x(x_unique)
+            .y(y_unique)
+            .name("Surface");
+
+        plot.add_trace(surface);
+        let dst = PathBuf::from("example.png");
+        plot.write_image("example.png", ImageFormat::PNG, 800, 600, 1.0);
+        assert!(dst.exists());
+        assert!(std::fs::remove_file(&dst).is_ok());
+        assert!(!dst.exists());
+        assert!(!plot.to_base64(ImageFormat::PNG, 1024, 680, 1.0).is_empty());
     }
 }

--- a/plotly/src/plot.rs
+++ b/plotly/src/plot.rs
@@ -584,12 +584,12 @@ impl PartialEq for Plot {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::{json, to_value};
-    use std::path::PathBuf;
-
     use super::*;
     use crate::Scatter;
-
+    #[cfg(not(target_os = "macos"))]
+    use base64::engine::general_purpose;
+    use serde_json::{json, to_value};
+    use std::path::PathBuf;
     fn create_test_plot() -> Plot {
         let trace1 = Scatter::new(vec![0, 1, 2], vec![6, 10, 2]).name("trace1");
         let mut plot = Plot::new();

--- a/plotly/src/plot.rs
+++ b/plotly/src/plot.rs
@@ -584,10 +584,8 @@ impl PartialEq for Plot {
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
-
-
     use serde_json::{json, to_value};
+    use std::path::PathBuf;
 
     use super::*;
     use crate::Scatter;

--- a/plotly/src/plot.rs
+++ b/plotly/src/plot.rs
@@ -586,10 +586,12 @@ impl PartialEq for Plot {
 mod tests {
     use super::*;
     use crate::Scatter;
-    #[cfg(not(target_os = "macos"))]
-    use base64::engine::general_purpose;
+
     use serde_json::{json, to_value};
     use std::path::PathBuf;
+    #[cfg(not(target_os = "macos"))]
+    use {base64::engine::general_purpose, base64::Engine};
+
     fn create_test_plot() -> Plot {
         let trace1 = Scatter::new(vec![0, 1, 2], vec![6, 10, 2]).name("trace1");
         let mut plot = Plot::new();

--- a/plotly_kaleido/src/lib.rs
+++ b/plotly_kaleido/src/lib.rs
@@ -300,6 +300,7 @@ mod tests {
         .unwrap()
     }
 
+    #[cfg(target_os = "macos")]
     fn create_test_surface() -> Value {
         to_value(json!({
             "data": [

--- a/plotly_kaleido/src/lib.rs
+++ b/plotly_kaleido/src/lib.rs
@@ -224,11 +224,9 @@ impl Kaleido {
                         "failed to spawn Kaleido binary at {}",
                         self.cmd_path.to_string_lossy()
                     )
-                        .to_string()
+                    .to_string()
                 )
             });
-
-
         {
             let plot_data = PlotData::new(plotly_data, format, width, height, scale).to_json();
             let mut process_stdin = process.stdin.take().unwrap();
@@ -339,7 +337,7 @@ mod tests {
             ],
             "layout": {}
         }))
-            .unwrap()
+        .unwrap()
     }
 
     #[test]
@@ -449,7 +447,6 @@ mod tests {
         assert!(file_size > 0,);
         assert!(std::fs::remove_file(dst.as_path()).is_ok());
     }
-    
     #[cfg(target_os = "macos")]
     #[test]
     fn save_surface_jpeg() {
@@ -464,7 +461,6 @@ mod tests {
         assert!(file_size > 0,);
         assert!(std::fs::remove_file(dst.as_path()).is_ok());
     }
-    
     #[cfg(target_os = "macos")]
     #[test]
     fn save_surface_webp() {
@@ -479,7 +475,6 @@ mod tests {
         assert!(file_size > 0,);
         assert!(std::fs::remove_file(dst.as_path()).is_ok());
     }
-    
     #[cfg(target_os = "macos")]
     #[test]
     fn save_surface_svg() {
@@ -494,7 +489,6 @@ mod tests {
         assert!(file_size > 0,);
         assert!(std::fs::remove_file(dst.as_path()).is_ok());
     }
-    
     #[cfg(target_os = "macos")]
     #[test]
     fn save_surface_pdf() {


### PR DESCRIPTION
Hi 👋,

This PR fixes **#241** by **omitting `--disable-gpu` on macOS + arm64**.  

spec.json:

```json
{"format":"png","width":800,"height":600,"scale":1.0,"data":{"config":{},"data":[{"name":"Surface","type":"surface","x":[1.0,2.0,3.0],"y":[4.0,5.0,6.0],"z":[[1.0,2.0,3.0],[4.0,5.0,6.0],[7.0,8.0,9.0]]}],"layout":{}}}
```

```bash
cat spec.json | ./kaleido plotly \
--disable-gpu \
--allow-file-access-from-files \
--disable-breakpad \
--disable-dev-shm-usage \
--disable-software-rasterizer \
--single-process \
--no-sandbox \
> out.b64
```
```bash
cat out.b64
```
```json
{"code": 0, "message": "Success", "result": null, "version": "0.2.1"}
{"code":525,"message":"error creating static canvas/context for image server","pdfBgColor":null,"format":"png","result":null,"width":800,"height":600,"scale":1}
```

so we never get any image data. The fix is still to omit `--disable-gpu`, but I wanted to be precise in the description.

### What the patch changes

```rust
// non‑macOS keeps the original flag set
#[cfg(not(target_os = "macos"))]
let cmd_args = vec![
    "plotly",
    "--disable-gpu",
    "--allow-file-access-from-files",
    "--disable-breakpad",
    "--disable-dev-shm-usage",
    "--disable-software-rasterizer",
    "--single-process",
    "--no-sandbox",
];

// macOS (Intel **and** Apple Silicon) – drop `--disable-gpu`
#[cfg(target_os = "macos")]
let cmd_args = vec![
    "plotly",
    "--allow-file-access-from-files",
    "--disable-breakpad",
    "--disable-dev-shm-usage",
    "--disable-software-rasterizer",
    "--single-process",
    "--no-sandbox",
];
```

* Only the `--disable-gpu` flag is removed on macOS; everything else remains untouched.  
* Tested on M1, M2 Pro and M4 Max – `write_image` now succeeds and the tests pass.  
* Behaviour on Linux and Windows is unchanged.

### Link to upstream discussion

<https://github.com/plotly/Kaleido/issues/323>

Let me know if you’d prefer the macOS check to be `target_arch = "aarch64"` only (i.e. keep the flag for Intel Macs). Happy to adjust!

— Joaquín
