### PR TITLE
Make offline_js_sources pub

### DIFF
--- a/plotly/src/plot.rs
+++ b/plotly/src/plot.rs
@@ -499,7 +499,7 @@ impl Plot {
         }
     }
 
-    fn offline_js_sources() -> String {
+    pub fn offline_js_sources() -> String {
         // tex-mml-chtml conflicts with tex-svg when generating Latex Titles
         // let local_tex_mml_js = include_str!("../templates/tex-mml-chtml-3.2.0.js");
         let local_tex_svg_js = include_str!("../templates/tex-svg-3.2.2.js");


### PR DESCRIPTION
This function is useful outside of the crate. Example use case: assembling multiple plotly chart `div` HTML elements into a single page, after injecting the plotly scripts via `offline_js_sources`. I've been able to then embed plotly graphs inside HTML pages generated with rusts `mdbook`, however I had to replicate this function externally - which is OK but creates a problem when bumping plotly as I would have to re-download these scripts which may change.