### PR TITLE
make plotly_static last crate to publish as currently will fail

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,9 @@ jobs:
     - run: sleep 10
     - run: cargo publish --allow-dirty -p plotly_kaleido
     - run: sleep 10
-    - run: cargo publish --allow-dirty -p plotly_static --features webdriver_download,chromedriver
-    - run: sleep 10
     - run: cargo publish --allow-dirty -p plotly
+    - run: sleep 10
+    - run: cargo publish --allow-dirty -p plotly_static --features webdriver_download,chromedriver
 
   create-gh-release:
     name: Deploy to GH Releases

--- a/plotly_static/Cargo.toml
+++ b/plotly_static/Cargo.toml
@@ -8,7 +8,7 @@ workspace = ".."
 homepage = "https://github.com/plotly/plotly.rs"
 repository = "https://github.com/plotly/plotly.rs"
 edition = "2021"
-keywords = ["plot", "static", "image", "export", "chart", "plotly", "ndarray"]
+keywords = ["plotly", "static", "image", "export", "webdriver"]
 
 exclude = ["target/*"]
 


### PR DESCRIPTION
  - plotly_static needs to be added to the same crates.io token