### PR TITLE
Re-export ImageFormat from plotly_static into plotly package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.5] - 2025-07-30
+
+### Fixed  
+
+- [[#345](https://github.com/plotly/plotly.rs/pull/345)] Re-export `ImageFormat` from `plotly_static` into `plotly` 
+
 ## [0.13.4] - 2025-07-17
 
 ### Fixed  

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ plotly = { version = "0.13", features = ["static_export_default"] }
 This supports PNG, JPEG, WEBP, SVG, and PDF formats:
 
 ```rust
-use plotly::{Plot, Scatter, ImageFormat};
+use plotly::{Plot, Scatter,ImageFormat};
 
 let mut plot = Plot::new();
 plot.add_trace(Scatter::new(vec![0, 1, 2], vec![2, 1, 0]));
@@ -164,7 +164,9 @@ Kaleido binaries are available on Github [release page](https://github.com/plotl
 
 ## Usage Within a WASM Environment
 
-`Plotly.rs` can be used with a WASM-based frontend framework. The needed dependencies are automatically enabled for `wasm32` targets at compile time and there is no longer a need for the custom `wasm` flag in this crate. Note that the `kaleido` and `plotly_static` features are not supported in WASM environments and will throw a compilation error if enabled. 
+`Plotly.rs` can be used with a WASM-based frontend framework. Note that the `kaleido` and `plotly_static` static export features are not supported in WASM environments and will throw a compilation error if used. 
+
+The needed dependencies are automatically enabled for `wasm32` targets at compile time and there is no longer a need for the custom `wasm` flag in this crate.
 
 First, make sure that you have the Plotly JavaScript library in your base HTML template:
 

--- a/docs/book/src/fundamentals/static_image_export.md
+++ b/docs/book/src/fundamentals/static_image_export.md
@@ -57,8 +57,7 @@ plotly = { version = "0.13", features = ["static_export_default"] }
 ### Simple Export
 
 ```rust
-use plotly::{Plot, Scatter};
-use plotly::plotly_static::ImageFormat;
+use plotly::{Plot, Scatter, ImageFormat};
 
 let mut plot = Plot::new();
 plot.add_trace(Scatter::new(vec![1, 2, 3], vec![4, 5, 6]));

--- a/plotly/Cargo.toml
+++ b/plotly/Cargo.toml
@@ -52,7 +52,7 @@ dyn-clone = "1"
 erased-serde = "0.4"
 image = { version = "0.25", optional = true }
 plotly_derive = { version = "0.13", path = "../plotly_derive" }
-plotly_static = { version = "0.0.3", path = "../plotly_static", optional = true }
+plotly_static = { version = "0.0", path = "../plotly_static", optional = true }
 plotly_kaleido = { version = "0.13", path = "../plotly_kaleido", optional = true }
 ndarray = { version = "0.16", optional = true }
 once_cell = "1"

--- a/plotly/src/lib.rs
+++ b/plotly/src/lib.rs
@@ -57,10 +57,6 @@ pub use common::color;
 pub use configuration::Configuration;
 pub use layout::Layout;
 pub use plot::{Plot, Trace, Traces};
-#[cfg(feature = "kaleido")]
-pub use plotly_kaleido::ImageFormat;
-#[cfg(feature = "plotly_static")]
-pub use plotly_static;
 // Also provide easy access to modules which contain additional trace-specific types
 pub use traces::{
     box_plot, contour, heat_map, histogram, image, mesh3d, sankey, scatter, scatter3d,
@@ -74,6 +70,11 @@ pub use traces::{
 
 pub trait Restyle: serde::Serialize {}
 pub trait Relayout {}
+
+#[cfg(feature = "kaleido")]
+pub use plotly_kaleido::ImageFormat;
+#[cfg(feature = "plotly_static")]
+pub use plotly_static::{self, ImageFormat};
 
 // Not public API.
 #[doc(hidden)]

--- a/plotly_static/Cargo.toml
+++ b/plotly_static/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plotly_static"
-version = "0.0.3"
+version = "0.0.4"
 description = "Export Plotly graphs to static images using WebDriver"
 authors = ["Andrei Gherghescu andrei-ng@protonmail.com"]
 license = "MIT"

--- a/plotly_static/README.md
+++ b/plotly_static/README.md
@@ -56,7 +56,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-plotly_static = { version = "0.0.3", features = ["chromedriver", "webdriver_download"] }
+plotly_static = { version = "0.0.4", features = ["chromedriver", "webdriver_download"] }
 serde_json = "1.0"
 ```
 

--- a/plotly_static/examples/README.md
+++ b/plotly_static/examples/README.md
@@ -8,17 +8,17 @@ This example demonstrates how to use the `plotly_static` crate with `clap` to cr
 
 Export a plot from a JSON file (using Chrome driver):
 ```bash
-cargo run --example main --features chromedriver -- -i sample_plot.json -o my_plot -f png
+cargo run --example generate_static --features chromedriver -- -i sample_plot.json -o my_plot -f png
 ```
 
 Export a plot from a JSON file (using Firefox/Gecko driver):
 ```bash
-cargo run --example main --features geckodriver -- -i sample_plot.json -o my_plot -f png
+cargo run --example generate_static --features geckodriver -- -i sample_plot.json -o my_plot -f png
 ```
 
 Export a plot from stdin:
 ```bash
-cat sample_plot.json | cargo run --example main --features chromedriver -- -f svg -o output
+cat sample_plot.json | cargo run --example generate_static --features chromedriver -- -f svg -o output
 ```
 
 ### Web Driver Options
@@ -31,10 +31,10 @@ The example supports two different web drivers for rendering plots:
 You must specify one of these features when running the example. For example:
 ```bash
 # Use Chrome driver
-cargo run --example main --features chromedriver -- -i plot.json -o output.png
+cargo run --example generate_static --features chromedriver -- -i plot.json -o output.png
 
 # Use Firefox driver  
-cargo run --example main --features geckodriver -- -i plot.json -o output.png
+cargo run --example generate_static --features geckodriver -- -i plot.json -o output.png
 ```
 
 ### Logging
@@ -43,13 +43,13 @@ The example uses `env_logger` for logging. You can enable different log levels u
 
 ```bash
 # Enable info level logging
-RUST_LOG=info cargo run --example main --features chromedriver -- -i sample_plot.json -o my_plot -f png
+RUST_LOG=info cargo run --example generate_static --features chromedriver -- -i sample_plot.json -o my_plot -f png
 
 # Enable debug level logging for more verbose output
-RUST_LOG=debug cargo run --example main --features geckodriver -- -i sample_plot.json -o my_plot -f png
+RUST_LOG=debug cargo run --example generate_static --features geckodriver -- -i sample_plot.json -o my_plot -f png
 
 # Enable all logging levels
-RUST_LOG=trace cargo run --example main --features chromedriver -- -i sample_plot.json -o my_plot -f png
+RUST_LOG=trace cargo run --example generate_static --features chromedriver -- -i sample_plot.json -o my_plot -f png
 ```
 
 ### Command Line Options
@@ -66,18 +66,18 @@ RUST_LOG=trace cargo run --example main --features chromedriver -- -i sample_plo
 
 Export to PNG with custom dimensions:
 ```bash
-cargo run --example main --features chromedriver -- -i sample_plot.json -o plot -f png --width 1200 --height 800
+cargo run --example generate_static --features chromedriver -- -i sample_plot.json -o plot -f png --width 1200 --height 800
 ```
 
 Export to SVG from stdin:
 ```bash
 echo '{"data":[{"type":"scatter","x":[1,2,3],"y":[4,5,6]}],"layout":{}}' | \
-cargo run --example main --features geckodriver -- -f svg -o scatter_plot
+cargo run --example generate_static --features geckodriver -- -f svg -o scatter_plot
 ```
 
 Export to PDF with high resolution:
 ```bash
-cargo run --example main --features chromedriver -- -i sample_plot.json -o report -f pdf --width 1600 --height 1200 -s 2.0
+cargo run --example generate_static --features chromedriver -- -i sample_plot.json -o report -f pdf --width 1600 --height 1200 -s 2.0
 ```
 
 ### JSON Format

--- a/plotly_static/src/lib.rs
+++ b/plotly_static/src/lib.rs
@@ -74,7 +74,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! plotly_static = { version = "0.0.3", features = ["chromedriver", "webdriver_download"] }
+//! plotly_static = { version = "0.0.4", features = ["chromedriver", "webdriver_download"] }
 //! ```
 //!
 //! ## Advanced Usage


### PR DESCRIPTION
 - fix plotly_static example
 - bump plotly_static and remove patch version from plotly_static when used in plotly crate

Closes #343 